### PR TITLE
Feat: Add proactive API key check on sidepanel load

### DIFF
--- a/background.js
+++ b/background.js
@@ -231,6 +231,10 @@ class NationAssistantBackground {
                     sendResponse({ success: true, data: { reloaded: true } });
                     break;
 
+                case MESSAGE_TYPES.CHECK_API_KEY:
+                    sendResponse({ success: true, data: { isConfigured: !!this.llmService.apiKey } });
+                    break;
+
                 default:
                     sendResponse({ success: false, error: 'Unknown message type' });
             }
@@ -397,16 +401,18 @@ class NationAssistantBackground {
             
         } catch (error) {
             logger.error('Chat with page failed:', error.message);
+
+            // For API key errors, pass the original message so the frontend can handle it.
+            if (error.message.includes('API key')) {
+                return { success: false, error: error.message };
+            }
             
-            // Provide user-friendly error messages
+            // Provide user-friendly error messages for other cases
             let userMessage = error.message;
-            
             if (error.message.includes('Extension context invalidated')) {
                 userMessage = 'Extension needs to be reloaded. Please refresh the page and try again.';
             } else if (error.message.includes('No active tab')) {
                 userMessage = 'No active tab found. Please make sure you have a webpage open and try again.';
-            } else if (error.message.includes('API key')) {
-                userMessage = 'API configuration issue. Please check your settings and ensure your API key is valid.';
             } else if (error.message.includes('network') || error.message.includes('fetch')) {
                 userMessage = 'Network connection issue. Please check your internet connection and try again.';
             }

--- a/services/constants.js
+++ b/services/constants.js
@@ -10,6 +10,7 @@ export const MESSAGE_TYPES = {
   SUMMARIZE_PAGE: 'summarizePage',
   EXPLAIN_PAGE: 'explainPage',
   LIST_KEY_POINTS: 'listKeyPoints',
+  CHECK_API_KEY: 'checkApiKey',
 };
 
 export const CONTEXT_MENU_IDS = {

--- a/sidepanel/main.js
+++ b/sidepanel/main.js
@@ -15,7 +15,8 @@ import {
     pauseStreamingAnimations,
     resumeStreamingAnimations,
     addAIMessage,
-    addSystemMessage
+    addSystemMessage,
+    showError
 } from './ui.js';
 import { loadCurrentTab, handleContextAction, hasContextAction, handleSendMessage } from './api.js';
 import { logger } from './utils.js';
@@ -27,6 +28,13 @@ async function init() {
         validateState();
 
         initUI();
+
+        // Check for API key first
+        const apiKeyResponse = await chrome.runtime.sendMessage({ type: MESSAGE_TYPES.CHECK_API_KEY });
+        if (!apiKeyResponse.data.isConfigured) {
+            showError('API key not configured. Please configure it in the options page.', { apiKey: true });
+            return; // Stop initialization
+        }
         setupEventListeners();
         await loadCurrentTab();
         await handleContextAction();


### PR DESCRIPTION
Adds a check when the sidepanel initializes to ensure an API key is configured. If the key is missing, it displays an error and a button prompting the user to go to the settings page.

This improves the user experience by immediately informing the user of the missing API key, rather than waiting for an action to fail.

Changes:
- Added `CHECK_API_KEY` message type in `services/constants.js`.
- Added a handler for `CHECK_API_KEY` in `background.js` to return the key's configuration status.
- Modified `sidepanel/main.js` to call this check on `init()` and display an error if the key is not configured.
- The previous fix to `background.js` to pass through original error messages is also included.